### PR TITLE
Modified derived path for litecoin [BIP44]

### DIFF
--- a/src/coins/litecoin.ts
+++ b/src/coins/litecoin.ts
@@ -48,7 +48,7 @@ export default class LiteCoin implements ICoin {
     const mnemonic = generateMnemonic();
     const seed = await mnemonicToSeed(mnemonic);
     const root = this.bip32.fromSeed(seed, this.network);
-    const account = root.derivePath("m/44'/0'/0'/0");
+    const account = root.derivePath("m/44'/2'/0'/0");
     const node = account.derive(0).derive(0);
 
     const ltcAddress = payments.p2pkh({


### PR DESCRIPTION
Following the specifications of [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels), the correct `coin_type` is added to the derived path.
Full list of `coin_types`, [here](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#registered-coin-types).