### PR TITLE
refactor: prevent types duplication

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,17 @@
   "type": "commonjs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./typings/index.d.ts",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js"
   },
   "scripts": {
     "clean": "rimraf ./dist",
+    "typings": "tsc --declaration --emitDeclarationOnly --declarationDir ./typings",
     "build:cjs": "tsc -p tsconfig-cjs.json",
     "build:esm": "tsc -p tsconfig.json",
-    "build": "npm run clean && npm run build:cjs && npm run build:esm",
+    "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run typings",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
     "test": "jest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
-        "declaration": true,
+        "declaration": false,
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "module": "ES2020",


### PR DESCRIPTION
The configuration has been fixed to prevent both subdirectories of dist from repeating the types